### PR TITLE
Allowing multiple secondary auction

### DIFF
--- a/contracts/facets/GBMFacet.sol
+++ b/contracts/facets/GBMFacet.sol
@@ -130,6 +130,7 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         uint256 _tid = s.tokenMapping[_auctionId].tokenId;
         uint256 _tam = s.tokenMapping[_auctionId].tokenAmount;
 
+        require(_ca != address(0x0), "claim: Auction does not exist");
         require(s.collections[_ca].biddingAllowed, "claim: Claiming is currently not allowed");
 		if(s.auctionSeller[_auctionId] == address(0x0)){ //If it's a primary auction
 			require(getAuctionEndTime(_auctionId) < block.timestamp, "claim: Auction has not yet ended");
@@ -217,7 +218,7 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         bytes4 _tokenKind,
         bool _useInitiator
     ) public onlyOwner {
-        modifyAnAuctionToken(_tokenContract, _tokenId, _tokenKind, _useInitiator, 0, 0, 1, 0);
+        modifyAnAuctionToken(_tokenContract, _tokenId, _tokenKind, _useInitiator, 0, 0, 1, 0, 0);
     }
 	
 	/// @notice Register an auction token and emit the relevant AuctionInitialized & AuctionStartTimeUpdated events
@@ -231,20 +232,19 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         uint256 _tokenId,
         bytes4 _tokenKind,
         uint256 _tokenAmount,
-        uint256 _auctionPresetID
+        uint256 _auctionPresetID,
+        uint256 _auctionStartTime
     ) public {
         address _tokenContract = s.secundaryMarketTokenContract[_contractID];
-        modifyAnAuctionToken(_tokenContract, _tokenId, _tokenKind, false, 0, 0, _tokenAmount, _auctionPresetID);
-		uint256 localIndex;
+        require(_tokenContract != address(0), "ContractID does not exist");
+        require(_auctionStartTime > block.timestamp, "Start time in the past");
+        require(s.auctionPresets[_auctionPresetID].duration != 0, "Preset parameters are not correct");
 		if (_tokenKind == bytes4(keccak256("ERC721"))){
             IERC721(_tokenContract).safeTransferFrom(msg.sender, address(this), _tokenId);
-			localIndex = s.erc721TokensIndex[_tokenContract][_tokenId] -1;
-			s.auctionSeller[s.auction721Mapping[_tokenContract][_tokenId][localIndex]] = msg.sender;
 		} else {
             IERC1155(_tokenContract).safeTransferFrom(msg.sender, address(this), _tokenId, _tokenAmount, "");
-			localIndex =  s.erc1155TokensIndex[_tokenContract][_tokenId] -1;
-			s.auctionSeller[s.auction1155Mapping[_tokenContract][_tokenId][localIndex]] = msg.sender;
 		}
+        modifyAnAuctionToken(_tokenContract, _tokenId, _tokenKind, false, 0, 0, _tokenAmount, _auctionPresetID, _auctionStartTime);
     }
 
 	/// @notice Register a token contract to be use in the secundary market
@@ -274,7 +274,8 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         uint256 _index,
         uint256 _rewriteBlock,
         uint256 _tokenAmount,
-        uint256 _auctionPresetID
+        uint256 _auctionPresetID,
+        uint256 _auctionStartTime
     ) internal {
 
 		uint256 _locIndex;
@@ -342,13 +343,10 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
 
             if(_rewriteBlock == 0){
                 _auctionId = uint256(keccak256(abi.encodePacked(_tokenContract, _tokenId, _tokenKind, _locIndex, block.number)));
-            } else {
-                _auctionId = uint256(keccak256(abi.encodePacked(_tokenContract, _tokenId, _tokenKind, _locIndex, _rewriteBlock)));
-            }
-
-            if (_rewriteBlock != 0) {
                 s.erc1155TokensIndex[_tokenContract][_tokenId] = s.erc1155TokensIndex[_tokenContract][_tokenId] + 1;
                 s.erc1155TokensUnderAuction[_tokenContract][_tokenId] = s.erc1155TokensUnderAuction[_tokenContract][_tokenId] + _tokenAmount;
+            } else {
+                _auctionId = uint256(keccak256(abi.encodePacked(_tokenContract, _tokenId, _tokenKind, _locIndex, _rewriteBlock)));
             }
 
             s.auction1155Mapping[_tokenContract][_tokenId][_locIndex] = _auctionId;
@@ -368,10 +366,10 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
             s.auctions[_auctionId].bidMultiplier = s.initiatorInfo.bidMultiplier;
         }
 
-        if (_auctionPresetID != 0) {
+        if (_auctionPresetID != 0) {            
             s.auctions[_auctionId].owner = LibDiamond.contractOwner();
-            s.auctions[_auctionId].startTime = s.auctionPresets[_auctionPresetID].startTime;
-            s.auctions[_auctionId].endTime = s.auctionPresets[_auctionPresetID].endTime;
+            s.auctions[_auctionId].startTime = _auctionStartTime;
+            s.auctions[_auctionId].endTime = _auctionStartTime + s.auctionPresets[_auctionPresetID].duration;
             s.auctions[_auctionId].hammerTimeDuration = s.auctionPresets[_auctionPresetID].hammerTimeDuration;
             s.auctions[_auctionId].bidDecimals = s.auctionPresets[_auctionPresetID].bidDecimals;
             s.auctions[_auctionId].stepMin = s.auctionPresets[_auctionPresetID].stepMin;
@@ -379,7 +377,7 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
             s.auctions[_auctionId].incMax = s.auctionPresets[_auctionPresetID].incMax;
             s.auctions[_auctionId].bidMultiplier = s.auctionPresets[_auctionPresetID].bidMultiplier;
 
-            require(s.auctions[_auctionId].startTime != 0, "Auction startTime has not been set");
+			s.auctionSeller[_auctionId] = msg.sender;
         }
 
         //Event emitted when an auction is being setup
@@ -400,6 +398,7 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         uint256 _tam = s.tokenMapping[_auctionID].tokenAmount;
         
         require(s.collections[_ca].biddingAllowed, "claim: Claiming is currently not allowed");
+        require(msg.sender == s.auctionSeller[_auctionID], "cancelAuction: Not the owner of the token");
         require(getAuctionEndTime(_auctionID) < block.timestamp, "cancelAuction: Auction has not yet ended");
         require(getAuctionEndTime(_auctionID) + getAuctionHammerTimeDuration(_auctionID) > block.timestamp, "cancelAuction: Cancellation time has already ended");
         
@@ -429,43 +428,40 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
 
 	/// @notice Register parameters of auction to be used as presets
     /// Throw if the token owner is not the GBM smart contract
-    function setAuctionPresets(uint256 _auctionPresetID, 
-        uint256 _startTime,
-        uint256 _endTime,
+    function setAuctionPresets(uint256 _auctionPresetID,
         uint256 _hammerTimeDuration,
         uint256 _bidDecimals,
         uint256 _stepMin,
         uint256 _incMin,
         uint256 _incMax,
-        uint256 _bidMultiplier
+        uint256 _bidMultiplier,
+        uint256 _duration
     ) external onlyOwner {
-        s.auctionPresets[_auctionPresetID].startTime = _startTime;
-        s.auctionPresets[_auctionPresetID].endTime = _endTime;
         s.auctionPresets[_auctionPresetID].hammerTimeDuration = _hammerTimeDuration;
         s.auctionPresets[_auctionPresetID].bidDecimals = _bidDecimals;
         s.auctionPresets[_auctionPresetID].stepMin = _stepMin;
         s.auctionPresets[_auctionPresetID].incMin = _incMin;
         s.auctionPresets[_auctionPresetID].incMax = _incMax;
         s.auctionPresets[_auctionPresetID].bidMultiplier = _bidMultiplier;
+        s.auctionPresets[_auctionPresetID].duration = _duration;
     }
 
-    function getAuctionPresets(uint256 _auctionPresetID) public view returns(uint256 _startTime,
-        uint256 _endTime,
+    function getAuctionPresets(uint256 _auctionPresetID) public view returns(
         uint256 _hammerTimeDuration,
         uint256 _bidDecimals,
         uint256 _stepMin,
         uint256 _incMin,
         uint256 _incMax,
-        uint256 _bidMultiplier) 
+        uint256 _bidMultiplier,
+        uint256 _duration)
     {
-        _startTime = s.auctionPresets[_auctionPresetID].startTime;
-        _endTime = s.auctionPresets[_auctionPresetID].endTime;
         _hammerTimeDuration = s.auctionPresets[_auctionPresetID].hammerTimeDuration;
         _bidDecimals = s.auctionPresets[_auctionPresetID].bidDecimals;
         _stepMin = s.auctionPresets[_auctionPresetID].stepMin;
         _incMin = s.auctionPresets[_auctionPresetID].incMin;
         _incMax = s.auctionPresets[_auctionPresetID].incMax;
         _bidMultiplier = s.auctionPresets[_auctionPresetID].bidMultiplier;
+        _duration = s.auctionPresets[_auctionPresetID].duration;
     }
 
     function getAuctionInfo(uint256 _auctionId) external view returns (Auction memory auctionInfo_) {

--- a/contracts/facets/GBMFacet.sol
+++ b/contracts/facets/GBMFacet.sol
@@ -235,7 +235,7 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         uint256 _auctionPresetID,
         uint256 _auctionStartTime
     ) public {
-        address _tokenContract = s.secundaryMarketTokenContract[_contractID];
+        address _tokenContract = s.secondaryMarketTokenContract[_contractID];
         require(_tokenContract != address(0), "ContractID does not exist");
         require(_auctionStartTime > block.timestamp, "Start time in the past");
         require(s.auctionPresets[_auctionPresetID].duration != 0, "Preset parameters are not correct");
@@ -251,8 +251,8 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
     /// Throw if the token owner is not the GBM smart contract
     /// @param _contractID Id of the token contract the auctionned token belong to
     /// @param _tokenContract The token contract the auctionned token belong to
-    function secundaryMarketTokenContract(uint256 _contractID, address _tokenContract) external onlyOwner {
-        s.secundaryMarketTokenContract[_contractID] = _tokenContract;
+    function secondaryMarketTokenContract(uint256 _contractID, address _tokenContract) external onlyOwner {
+        s.secondaryMarketTokenContract[_contractID] = _tokenContract;
     }
 
     /// @notice Register an auction token and emit the relevant AuctionInitialized & AuctionStartTimeUpdated events

--- a/contracts/facets/GBMFacet.sol
+++ b/contracts/facets/GBMFacet.sol
@@ -233,7 +233,7 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
         uint256 _tokenAmount,
         uint256 _auctionPresetID
     ) public {
-        address _tokenContract = s.secundaryMarketTokenContract[_contractID];
+        address _tokenContract = s.secondaryMarketTokenContract[_contractID];
         modifyAnAuctionToken(_tokenContract, _tokenId, _tokenKind, false, 0, 0, _tokenAmount, _auctionPresetID);
 		uint256 localIndex;
 		if (_tokenKind == bytes4(keccak256("ERC721"))){
@@ -251,8 +251,8 @@ contract GBMFacet is IGBM, IERC1155TokenReceiver, IERC721TokenReceiver, Modifier
     /// Throw if the token owner is not the GBM smart contract
     /// @param _contractID Id of the token contract the auctionned token belong to
     /// @param _tokenContract The token contract the auctionned token belong to
-    function secundaryMarketTokenContract(uint256 _contractID, address _tokenContract) external onlyOwner {
-        s.secundaryMarketTokenContract[_contractID] = _tokenContract;
+    function secondaryMarketTokenContract(uint256 _contractID, address _tokenContract) external onlyOwner {
+        s.secondaryMarketTokenContract[_contractID] = _tokenContract;
     }
 
     /// @notice Register an auction token and emit the relevant AuctionInitialized & AuctionStartTimeUpdated events

--- a/contracts/interfaces/IGBM.sol
+++ b/contracts/interfaces/IGBM.sol
@@ -34,6 +34,8 @@ interface IGBM {
 
     event Auction_ItemClaimed(uint256 indexed _auctionID);
 
+    event AuctionCancelled(uint256 indexed _auctionId, uint256 _tokenId);
+
     //    function bid(
     //        uint256 _auctionID,
     //        uint256 _bidAmount,
@@ -46,13 +48,11 @@ interface IGBM {
 
     function erc20Currency() external view returns (address);
 
-    function getAuctionID(address _contract, uint256 _tokenID) external view returns (uint256);
+	//DEPRECATED
+    function getAuctionID(address _contract, uint256 _tokenID) external view returns (uint256); 
 
-    function getAuctionID(
-        address _contract,
-        uint256 _tokenID,
-        uint256 _tokenIndex
-    ) external view returns (uint256);
+	//DEPRECATED
+    function getAuctionID(address _contract, uint256 _tokenID, uint256 _tokenIndex) external view returns (uint256);
 
     function getTokenId(uint256 _auctionId) external view returns (uint256);
 
@@ -83,4 +83,6 @@ interface IGBM {
     function getAuctionIncMax(uint256 _auctionId) external view returns (uint256);
 
     function getAuctionBidMultiplier(uint256 _auctionId) external view returns (uint256);
+	
+	function getAuctionID(address _contract, uint256 _tokenID, uint256 _tokenIndex, bytes4 _tokenKind) external view returns (uint256);
 }

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -56,6 +56,7 @@ struct Collection {
     uint256 incMax; // maximal earned incentives
     uint256 bidMultiplier; // bid incentive growth multiplier
     bool biddingAllowed; // Allow to start/pause ongoing auctions
+    uint256 duration;
 }
 
 struct AppStorage {

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -65,7 +65,10 @@ struct AppStorage {
     //Contract address storing the ERC20 currency used in auctions
     address erc20Currency;
     mapping(uint256 => TokenRepresentation) tokenMapping; //_auctionId => token_primaryKey
-    mapping(address => mapping(uint256 => mapping(uint256 => uint256))) auctionMapping; // contractAddress => tokenId => TokenIndex => _auctionId
+
+    //DEPRECATED DUE TO DUAL TOKEN ID SAME CONTRACT
+    mapping(address => mapping(uint256 => mapping(uint256 => uint256))) auctionMapping; // contractAddress => tokenId => TokenIndex => _auctionId  
+
     //var storing individual auction settings. if != null, they take priority over collection settings
     mapping(uint256 => Auction) auctions; //_auctionId => auctions
     mapping(uint256 => bool) auctionItemClaimed;
@@ -74,6 +77,12 @@ struct AppStorage {
     mapping(address => mapping(uint256 => uint256)) erc1155TokensIndex; //Contract => TokenID => Amount being auctionned
     mapping(address => mapping(uint256 => uint256)) erc1155TokensUnderAuction; //Contract => TokenID => Amount being auctionned
     bytes backendPubKey;
+
+    //Secondary market patch
+    mapping(address => mapping(uint256 => mapping(uint256 => uint256))) auction721Mapping; // contractAddress => tokenId => TokenIndex => _auctionId 
+    mapping(address => mapping(uint256 => mapping(uint256 => uint256))) auction1155Mapping; // contractAddress => tokenId => TokenIndex => _auctionId 
+    mapping(address => mapping(uint256 => uint256)) erc721TokensIndex; //Contract => TokenID => Iteration of being auctionned
+    mapping(uint256 => address) auctionSeller; //auctionID => Auction seller Mapping storing who is the seller of a token for a specific auction. 
 }
 
 contract Modifiers {

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -85,7 +85,7 @@ struct AppStorage {
     mapping(address => mapping(uint256 => uint256)) erc721TokensIndex; //Contract => TokenID => Iteration of being auctionned
     mapping(uint256 => address) auctionSeller; //auctionID => Auction seller Mapping storing who is the seller of a token for a specific auction. 
     mapping(uint256 => Collection) auctionPresets; // presestID => Configuration parameters collection
-    mapping(uint256 => address) secundaryMarketTokenContract; //tokenContractId => Token contract address
+    mapping(uint256 => address) secondaryMarketTokenContract; //tokenContractId => Token contract address
 }
 
 contract Modifiers {

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -84,6 +84,8 @@ struct AppStorage {
     mapping(address => mapping(uint256 => mapping(uint256 => uint256))) auction1155Mapping; // contractAddress => tokenId => TokenIndex => _auctionId 
     mapping(address => mapping(uint256 => uint256)) erc721TokensIndex; //Contract => TokenID => Iteration of being auctionned
     mapping(uint256 => address) auctionSeller; //auctionID => Auction seller Mapping storing who is the seller of a token for a specific auction. 
+    mapping(uint256 => Collection) auctionPresets; // presestID => Configuration parameters collection
+    mapping(uint256 => address) secundaryMarketTokenContract; //tokenContractId => Token contract address
 }
 
 contract Modifiers {

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -86,7 +86,7 @@ struct AppStorage {
     mapping(address => mapping(uint256 => uint256)) erc721TokensIndex; //Contract => TokenID => Iteration of being auctionned
     mapping(uint256 => address) auctionSeller; //auctionID => Auction seller Mapping storing who is the seller of a token for a specific auction. 
     mapping(uint256 => Collection) auctionPresets; // presestID => Configuration parameters collection
-    mapping(uint256 => address) secundaryMarketTokenContract; //tokenContractId => Token contract address
+    mapping(uint256 => address) secondaryMarketTokenContract; //tokenContractId => Token contract address
 }
 
 contract Modifiers {

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -7,6 +7,7 @@ struct TokenRepresentation {
     address contractAddress; // The contract address
     uint256 tokenId; // The ID of the token on the contract
     bytes4 tokenKind; // The ERC name of the token implementation bytes4(keccak256("ERC721")) or bytes4(keccak256("ERC1155"))
+    uint256 tokenAmount; // The amount of units that are sold in the auction
 }
 
 struct ContractAddresses {


### PR DESCRIPTION
/!\

There should be no problem from a pure smart contract perspective (it only change the way the auctionID is generated by adding the block number as an additional entropy source), however it might have ecosystem consequence as the mapping tokenID => AuctionID get rest to 0 at the end of an ERC721 token auction.

Please check your backend.

Moreover, those secondary auction still need to be triggered by the smart contract "owner", as a REQUIREMENT for GBM secondary auction is that the NFT is in escrow/locked for the duration of the auction. Incentive for transfer-before-auction-end fraud would be too high if not disabled. (due to actual bid incentives).
It is up to you to either take those token into escrow or modify the token smart contract to disable "transfer" while an auction is ongoing.